### PR TITLE
Control relative filter wildcard position via .env

### DIFF
--- a/config/pipeline-query-collection.php
+++ b/config/pipeline-query-collection.php
@@ -1,8 +1,16 @@
 <?php
+
+use Baro\PipelineQueryCollection\Enums\WildcardPositionEnum;
+
 // config for Baro/PipelineQueryCollection
 return [
     // key to detect param to filter
     'detect_key' => env('PIPELINE_QUERY_COLLECTION_DETECT_KEY', ''),
+
+    // Allow the default wildcard position for relative filters to be controlled via .env.
+    'relative_wildcard_position' => WildcardPositionEnum::tryFrom(
+        env('PIPELINE_QUERY_COLLECTION_WILDCARD_POSITION', 'both')
+    ),
 
     // type of postfix for date filters
     'date_from_postfix' => env('PIPELINE_QUERY_COLLECTION_DATE_FROM_POSTFIX', 'from'),


### PR DESCRIPTION
Hello!

Firstly, thank you for this package - it makes it very simple and easy to create lots of nice filters for my Laravel applications!

This PR adds the ability for developers to control the default wildcard position via the .env file, by adding the following code to the published config file:

```php
'relative_wildcard_position' => WildcardPositionEnum::tryFrom(
    env('PIPELINE_QUERY_COLLECTION_WILDCARD_POSITION', 'both')
),
```

The main reason for this is to reduce the burden and time for developers to update this default behaviour, without having to push out a code change.