### PR TITLE
fix date filters on sqlite

### DIFF
--- a/src/DateFromFilter.php
+++ b/src/DateFromFilter.php
@@ -27,7 +27,7 @@ class DateFromFilter extends BaseFilter
     {
         $operator = $this->motion === MotionEnum::FIND ? '>=' : '>';
         foreach ($this->getSearchValue() as $value) {
-            $query->where($this->getSearchColumn(), $operator, $value);
+            $query->whereDate($this->getSearchColumn(), $operator, $value);
         }
         return $query;
     }

--- a/src/DateToFilter.php
+++ b/src/DateToFilter.php
@@ -27,7 +27,7 @@ class DateToFilter extends BaseFilter
     {
         $operator = $this->motion === MotionEnum::FIND ? '<=' : '<';
         foreach ($this->getSearchValue() as $value) {
-            $query->where($this->getSearchColumn(), $operator, $value);
+            $query->whereDate($this->getSearchColumn(), $operator, $value);
         }
         return $query;
     }


### PR DESCRIPTION
This PR updates the `apply` methods in both the `DateToFilter` and `DateFromFilter` to use eloquent's `whereDate` method, this will fix those wanting to run their test suits in Sqlite. This is due to the different way Sqlite handles filters with datetime and timestamp columns vs MySQL