### PR TITLE
Use SQLite as default test database

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,6 +64,7 @@ jobs:
               run: vendor/bin/pest
               env:
                   DB_CONNECTION: mysql
+                  DB_DATABASE: query_test
                   DB_USERNAME: user
                   DB_PASSWORD: secret
                   DB_PORT: ${{ job.services.mysql.ports[3306] }}
@@ -74,4 +75,3 @@ jobs:
                   DB_CONNECTION: sqlite
                   DB_DATABASE: ":memory:"
                   REDIS_PORT: 6379
-            

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,9 +37,9 @@
         <junit outputFile="build/report.junit.xml"/>
     </logging>
     <php>
-        <env name="DB_CONNECTION" value="mysql"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_USERNAME" value="root"/>
-        <env name="DB_DATABASE" value="query_test"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="3306"/>
     </php>


### PR DESCRIPTION
This PR switches the default testing database from MySQL to SQLite now that it is officially supported with #6.

The reason for this is so that developers and other contributors don't need to download and setup a MySQL environment to be able to run test suites.

Using SQLite as the default database engine for tests also improves the speed tests execute by ~1s (MySQL took 1.43 seconds vs 0.35s on SQLite using an M1 MacBook Pro)