### PR TITLE
Support for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "l3aro/pipeline-query-collection",
+    "name": "mikhail-konstantinou/pipeline-query-collection",
     "description": "A query database collection for use with Laravel Pipeline",
     "keywords": [
         "l3aro",

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^9.0"
+        "illuminate/contracts": "^10.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
         "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "l3aro/pipeline-query-collection",
+    "name": "mikhail-konstantinou/pipeline-query-collection",
     "description": "A query database collection for use with Laravel Pipeline",
     "keywords": [
         "l3aro",
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^10.0"
+        "illuminate/contracts": "^9.0|^10.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
         "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^7.0|^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mikhail-konstantinou/pipeline-query-collection",
+    "name": "l3aro/pipeline-query-collection",
     "description": "A query database collection for use with Laravel Pipeline",
     "keywords": [
         "l3aro",


### PR DESCRIPTION
It seems that some composer dependencies conflict with the requirements of laravel 10 framework. This issue does not allow projects that use this package, to upgrade to laravel 10. 

No breaking code changes were necessary, however a small update on the composer.json file was required. The package was tested on a brand new laravel 10 project and it worked without any issues

### Updated
Composer.json now requires the following:
- illuminate/contracts: ^10.0
- orchestra/testbench: ^8.0

### Additional comments
- Packages like phpunit or nunomaduro/collision could be updated, however this is not necessary and could be examined further whether this is something that should change. At the moment this can be ignored as some versions are still not stable to support these changes
- If it is strictly necessary to support both laravel 9 and laravel 10 on newer version of this package, then I can change the composer.json to support both versions (e.g. ^9.0|^10.0). In my opinion this is not necessary though as no changes have been made that affect the two. In my opinion a new version (e.g. 2.0) shall be enough. 