### PR TITLE
Relative Filter in many columns with one field

### DIFF
--- a/src/BaseFilter.php
+++ b/src/BaseFilter.php
@@ -12,6 +12,8 @@ abstract class BaseFilter extends BasePipe
 
     protected ?string $searchColumn = null;
 
+    protected mixed $searchColumns;
+
     protected mixed $searchValue = null;
 
     public function __construct()
@@ -70,6 +72,18 @@ abstract class BaseFilter extends BasePipe
         return $this->searchColumn ?? $this->field;
     }
 
+    public function filterOnColumns(mixed $searchColumns)
+    {
+        $this->searchColumns = $searchColumns;
+
+        return $this;
+    }
+
+    protected function getSearchColumns()
+    {
+        return $this->searchColumns ?? $this->field;
+    }
+
     public function ignore(mixed $ignore = '')
     {
         $this->ignore = $ignore;
@@ -93,11 +107,11 @@ abstract class BaseFilter extends BasePipe
 
     protected function shouldFilter(string $key)
     {
-       if (isset($this->searchValue)) {
+        if (isset($this->searchValue)) {
             return true;
-       }
+        }
 
-       if (!$this->request->has($key)) {
+        if (!$this->request->has($key)) {
             return false;
         }
 

--- a/src/FieldsRelativeFilter.php
+++ b/src/FieldsRelativeFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Baro\PipelineQueryCollection;
+
+use Baro\PipelineQueryCollection\Enums\WildcardPositionEnum;
+
+class FieldsRelativeFilter extends BaseFilter
+{
+    private $wildcardPosition;
+
+    public function __construct($field, $columns, WildcardPositionEnum|string $wildcardPosition = null)
+    {
+        parent::__construct();
+        $this->field = $field;
+        $this->searchColumns = $columns;
+        if (is_null($wildcardPosition)) {
+            $wildcardPosition = config('pipeline-query-collection.relative_wildcard_position', WildcardPositionEnum::BOTH);
+        }
+        if (!$wildcardPosition instanceof WildcardPositionEnum) {
+            $wildcardPosition = WildcardPositionEnum::from($wildcardPosition);
+        }
+        $this->wildcardPosition = $wildcardPosition;
+    }
+
+    public static function make($field, $columns, WildcardPositionEnum|string $wildcardPosition = null)
+    {
+        return new self($field, $columns, $wildcardPosition);
+    }
+
+    protected function apply(): static
+    {
+        foreach ($this->getSearchValue() as $value) {
+            foreach ($this->getSearchColumns() as $column) {
+                $this->query->where($column, 'like', $this->computeSearchValue($value));
+            }
+        }
+        return $this;
+    }
+
+    private function computeSearchValue($value)
+    {
+        return match ($this->wildcardPosition) {
+            WildcardPositionEnum::RIGHT => "$value%",
+            WildcardPositionEnum::LEFT => "%$value",
+            default => "%$value%",
+        };
+    }
+}


### PR DESCRIPTION
I created a Relative Filter thats does the filter in many columns with one only field, this is very helpful when you want to filter on the all fields and one filter at the same time.

names:

-   DeivisF
-   DeivisG

url?name=Deivis&search=DeivisF

```
    public function getFilters(): array
    {
        return [
            new RelativeFilter('name'), 
            new RelativeFilter('lastname'),
            new FieldsRelativeFilter("search", ['name', 'lastname']),
            new Sort(),
        ];
    }
```